### PR TITLE
Fix object creation + flaky tests

### DIFF
--- a/python-sdk/hibachi_xyz/api.py
+++ b/python-sdk/hibachi_xyz/api.py
@@ -202,7 +202,7 @@ class HibachiApiClient:
                 FutureContract, contract
             )
 
-        fee_config = FeeConfig(**exchange_info["feeConfig"])
+        fee_config = create_with(FeeConfig, exchange_info["feeConfig"])
 
         # Parse future contracts
         future_contracts = [
@@ -211,7 +211,9 @@ class HibachiApiClient:
         ]
 
         # Parse withdrawal limit
-        withdrawal_limit = WithdrawalLimit(**exchange_info["instantWithdrawalLimit"])
+        withdrawal_limit = create_with(
+            WithdrawalLimit, exchange_info["instantWithdrawalLimit"]
+        )
 
         # Parse maintenance windows
         maintenance_windows = [
@@ -298,12 +300,13 @@ class HibachiApiClient:
 
         self.future_contracts = {}
         for market in market_inventory["markets"]:
-            contract = FutureContract(**market["contract"])
+            contract = create_with(FutureContract, market["contract"])
             self.future_contracts[contract.symbol] = contract
 
         markets = [
             Market(
-                contract=FutureContract(**m["contract"]), info=MarketInfo(**m["info"])
+                contract=create_with(FutureContract, m["contract"]),
+                info=create_with(MarketInfo, m["info"]),
             )
             for m in market_inventory["markets"]
         ]
@@ -313,7 +316,7 @@ class HibachiApiClient:
                 create_with(CrossChainAsset, cca)
                 for cca in market_inventory["crossChainAssets"]
             ],
-            feeConfig=FeeConfig(**market_inventory["feeConfig"]),
+            feeConfig=create_with(FeeConfig, market_inventory["feeConfig"]),
             markets=markets,
             tradingTiers=[
                 create_with(TradingTier, tt) for tt in market_inventory["tradingTiers"]
@@ -324,14 +327,16 @@ class HibachiApiClient:
 
     def get_prices(self, symbol: str) -> PriceResponse:
         response = self.__send_simple_request(f"/market/data/prices?symbol={symbol}")
-        response["fundingRateEstimation"] = FundingRateEstimation(
-            **response["fundingRateEstimation"]
+        response["fundingRateEstimation"] = create_with(
+            FundingRateEstimation,
+            response["fundingRateEstimation"],
         )
         return create_with(PriceResponse, response)
 
     def get_stats(self, symbol: str) -> StatsResponse:
-        return StatsResponse(
-            **self.__send_simple_request(f"/market/data/stats?symbol={symbol}")
+        return create_with(
+            StatsResponse,
+            self.__send_simple_request(f"/market/data/stats?symbol={symbol}"),
         )
 
     def get_trades(self, symbol: str) -> TradesResponse:

--- a/python-sdk/test_hibachi.py
+++ b/python-sdk/test_hibachi.py
@@ -268,7 +268,6 @@ def test_get_account_info():
         assert isinstance(asset, Asset)
         assert isinstance(asset.quantity, str)
         assert isinstance(asset.symbol, str)
-        assert float(asset.quantity)
 
     if len(accountinfo.positions) > 0:
         position = accountinfo.positions[0]
@@ -524,14 +523,6 @@ def test_batch_order():
 
     # ensure we have some BTC/USDT-P position to sell
     account_info = client.get_account_info()
-
-    check = False
-    for position in account_info.positions:
-        print(f"Position: \t{position.symbol} \t{position.quantity}")
-        if position.symbol == "BTC/USDT-P" and float(position.quantity) > 0:
-            check = True
-
-    assert check, "Not enough BTC/USDT-P position to sell"
 
     # place some test orders to update and cancel in batch
     (nonce, limit_order_id) = client.place_limit_order(
@@ -811,7 +802,7 @@ def test_cancel_order():
         quantity=0.0001,
         side=Side.ASK,
         max_fees_percent=0.005,
-        price=float(current_price.askPrice) * 1.05,
+        price=float(current_price.askPrice) * 10,
     )
     assert len(client.get_pending_orders().orders) == start_order_count + 1
     cancel_result = client.cancel_order(order_id=order_id, nonce=nonce)
@@ -822,7 +813,7 @@ def test_cancel_order():
         quantity=0.0001,
         side=Side.ASK,
         max_fees_percent=0.005,
-        price=float(current_price.askPrice) * 1.05,
+        price=float(current_price.askPrice) * 10,
     )
     assert len(client.get_pending_orders().orders) == start_order_count + 1
     cancel_result = client.cancel_order(order_id=order_id)
@@ -833,7 +824,7 @@ def test_cancel_order():
         quantity=0.0001,
         side=Side.ASK,
         max_fees_percent=0.005,
-        price=float(current_price.askPrice) * 1.05,
+        price=float(current_price.askPrice) * 10,
     )
     assert len(client.get_pending_orders().orders) == start_order_count + 1
     cancel_result = client.cancel_order(nonce=nonce)
@@ -863,7 +854,7 @@ def test_cancel_all_orders():
         quantity=0.0001,
         side=Side.ASK,
         max_fees_percent=0.005,
-        price=float(current_price.askPrice) * 1.05,
+        price=float(current_price.askPrice) * 10,
     )
 
     assert nonce != None

--- a/python-sdk/test_websocket.py
+++ b/python-sdk/test_websocket.py
@@ -234,10 +234,8 @@ async def test_account_websocket():
             result.accountSnapshot, AccountSnapshot
         ), "accountSnapshot missing"
         assert isinstance(result.accountSnapshot.positions, list)
-        assert result.accountSnapshot.positions, "No positions returned"
-
-        first_position = result.accountSnapshot.positions[0]
-        assert isinstance(first_position, Position), "Invalid Position object"
+        for position in result.accountSnapshot.positions:
+            assert isinstance(position, Position), "Invalid Position object"
 
     finally:
         await client.disconnect()


### PR DESCRIPTION
* use `create_with` everywhere possible. I added this helper in a previous fix to future proof our api so that adding fields will not blow up this sdk
* remove flaky expectations from the api tests
* where we want an order not to match, place it with a ridiculously high price, not just one 5% above the spread which may be hit in certain markets.