### PR TITLE
fix: add get_open_orders and remove str() from cancel_order

### DIFF
--- a/python-sdk/hibachi_xyz/api_ws_trade.py
+++ b/python-sdk/hibachi_xyz/api_ws_trade.py
@@ -98,6 +98,15 @@ class HibachiWSTradeClient:
 
     """
 
+    async def get_open_orders(self, symbol: str):
+        """
+        Fetches open orders for the specified symbol via WebSocket.
+        """
+        return await self.place_request(
+            action="GET_OPEN_ORDERS",
+            payload={"symbol": symbol}
+        )
+
     def __init__(
         self,
         api_key: str,
@@ -195,7 +204,7 @@ class HibachiWSTradeClient:
             "method": "order.cancel",
             "params": {
                 "orderId": str(orderId),
-                "accountId": str(self.account_id),
+                "accountId": self.account_id,
                 # "nonce": str(nonce)
             },
             "signature": prepare_packet.get("signature"),


### PR DESCRIPTION
### Description

This pull request includes two critical improvements to the `HibachiWSTradeClient` class:

---

### ✅ 1. Added `get_open_orders()` method

Allows retrieval of current open orders over WebSocket.
This is essential for bots to check if an order is still active before placing a new one, improving safety and avoiding duplicate entries.

---

### 🛠 2. Fixed `order.cancel` payload

Replaced:

```python
"accountId": str(self.account_id)
```

with:

```python
"accountId": self.account_id
```

Passing `accountId` as a string caused cancel requests to silently fail. This fix ensures order cancellation works correctly.

---

### 💡 Context

These changes were implemented to support a production trading bot using the SDK.
Both fixes were tested live and resolved real-world issues with order tracking and cancellation.

---

Thank you for reviewing and maintaining this SDK!
