### PR TITLE
Use `decimal.Decimal` when converting floats to payloads for signing

### DIFF
--- a/python-sdk/hibachi_xyz/api.py
+++ b/python-sdk/hibachi_xyz/api.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from decimal import Decimal
 from hashlib import sha256
 import hmac
 from math import floor
@@ -75,9 +76,9 @@ from hibachi_xyz.helpers import (
 
 def price_to_bytes(price: float, contract: FutureContract) -> bytes:
     return int(
-        price
-        * pow(2, 32)
-        * pow(10, contract.settlementDecimals - contract.underlyingDecimals)
+        Decimal(full_precision_string(price))
+        * pow(Decimal("2"), 32)
+        * pow(Decimal("10"), contract.settlementDecimals - contract.underlyingDecimals)
     ).to_bytes(8, "big")
 
 
@@ -1430,12 +1431,12 @@ class HibachiApiClient:
 
         nonce_bytes = nonce.to_bytes(8, "big")
         contract_id_bytes = contract_id.to_bytes(4, "big")
-        quantity_bytes = int(quantity * pow(10, contract.underlyingDecimals)).to_bytes(
+        quantity_bytes = int(Decimal(full_precision_string(quantity)) * pow(10, contract.underlyingDecimals)).to_bytes(
             8, "big"
         )
         price_bytes = b"" if price is None else price_to_bytes(price, contract)
         side_bytes = (0 if side.value == "ASK" else 1).to_bytes(4, "big")
-        max_fees_percent_bytes = int(max_fees_percent * pow(10, 8)).to_bytes(8, "big")
+        max_fees_percent_bytes = int(Decimal(full_precision_string(max_fees_percent)) * pow(10, 8)).to_bytes(8, "big")
 
         payload = (
             nonce_bytes


### PR DESCRIPTION
Context: [ENG-6214: \[Investigation\] \[Python SDK\] Signature issues on small quantities](https://linear.app/hibachi-xyz/issue/ENG-6214/investigation-python-sdk-signature-issues-on-small-quantities)

# Testing
Running the test script using the same payload with the new version of the SDK succeeds:
```
(
    api_endpoint,
    data_api_endpoint,
    api_key,
    account_id,
    private_key,
    public_key,
    dst_public_key,
) = setup_environment()

client = HibachiApiClient(
        api_endpoint,
        data_api_endpoint,
        account_id=account_id,
        api_key=api_key,
        private_key=private_key,
    )

response = client.place_market_order("BTC/USDT-P", 0.0002459091, Side.BUY, 0.0009)
print(response)
```

<img width="1385" height="150" alt="image" src="https://github.com/user-attachments/assets/8d7d2ea6-e1b9-4742-836c-0b4a3dbd3118" />


