### PR TITLE
Using logging module instead of prints

### DIFF
--- a/python-sdk/hibachi_xyz/api_ws_account.py
+++ b/python-sdk/hibachi_xyz/api_ws_account.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 import time
 from typing import Callable, Dict, List
 
@@ -7,6 +8,8 @@ from hibachi_xyz.executors import WsConnection
 from hibachi_xyz.helpers import connect_with_retry, DEFAULT_API_URL, get_hibachi_client
 from hibachi_xyz.types import AccountSnapshot, AccountStreamStartResult, Position
 from hibachi_xyz.errors import WebSocketConnectionError
+
+log = logging.getLogger(__name__)
 
 
 class HibachiWSAccountClient:
@@ -80,7 +83,7 @@ class HibachiWSAccountClient:
         response = await self.websocket.recv()
         parsed = json.loads(response)
         if parsed.get("status") == 200:
-            print("pong!")
+            log.debug("pong!")
 
     async def listen(self) -> dict | None:
         try:
@@ -97,9 +100,9 @@ class HibachiWSAccountClient:
             await self.ping()
             return None
         except WebSocketConnectionError as e:
-            print(f"[MarketClient] WebSocket closed: {e}")
+            log.warning("WebSocket closed: %s", e)
         except Exception as e:
-            print(f"[listen] WebSocket closed: {e}")
+            log.error("WebSocket closed: %s", e)
             raise
 
     async def disconnect(self):

--- a/python-sdk/hibachi_xyz/api_ws_market.py
+++ b/python-sdk/hibachi_xyz/api_ws_market.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import logging
 from dataclasses import asdict
 from typing import Callable, Dict, List
 
@@ -11,6 +12,8 @@ from hibachi_xyz.helpers import (
     get_hibachi_client,
 )
 from hibachi_xyz.types import WebSocketSubscription
+
+log = logging.getLogger(__name__)
 
 
 class HibachiWSMarketClient:
@@ -67,9 +70,9 @@ class HibachiWSMarketClient:
         except asyncio.CancelledError:
             pass
         except WebSocketConnectionError as e:
-            print(f"[MarketClient] WebSocket closed: {e}")
+            log.warning("WebSocket closed: %s", e)
         except Exception as e:
-            print(f"[MarketClient] Receive loop error: {e}")
+            log.error("Receive loop error: %s", e)
 
     async def disconnect(self):
         if self._receive_task:

--- a/python-sdk/hibachi_xyz/api_ws_trade.py
+++ b/python-sdk/hibachi_xyz/api_ws_trade.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import random
 import time
 from dataclasses import asdict
@@ -13,6 +14,8 @@ from hibachi_xyz.helpers import (
     DEFAULT_DATA_API_URL,
     print_data,
 )
+
+log = logging.getLogger(__name__)
 
 from .types import (
     EnableCancelOnDisconnectParams,
@@ -153,8 +156,8 @@ class HibachiWSTradeClient:
         response = await self.websocket.recv()
         response_data = json.loads(response)
 
-        print("ws place_order -------------------------------------------")
-        print_data(response_data)
+        log.debug("ws place_order -------------------------------------------")
+        log.debug("Response data: %s", response_data)
 
         # response_data["result"] = OrderPlaceResponseResult(**response_data["result"])
         # nonce: Nonce = prepare_packet.get("nonce")
@@ -166,8 +169,8 @@ class HibachiWSTradeClient:
 
         prepare_packet = self.api._cancel_order_request_data(orderId, nonce, False)
 
-        print("prepare_packet -------------------------------------------")
-        print_data(prepare_packet)
+        log.debug("prepare_packet -------------------------------------------")
+        log.debug("Prepare packet: %s", prepare_packet)
 
         message = {
             "id": self.message_id,
@@ -183,7 +186,7 @@ class HibachiWSTradeClient:
         response = await self.websocket.recv()
         response_data = json.loads(response)
 
-        print_data(response_data)
+        log.debug("Response data: %s", response_data)
 
         # return WebSocketResponse(**response_data)
         return response_data
@@ -247,7 +250,7 @@ class HibachiWSTradeClient:
         response = await self.websocket.recv()
         response_data = json.loads(response)
 
-        print_data(response_data)
+        log.debug("Response data: %s", response_data)
 
         response_data["result"] = Order(**response_data["result"])
         return OrderStatusResponse(**response_data)
@@ -290,7 +293,7 @@ class HibachiWSTradeClient:
         response = await self.websocket.recv()
         response_data = json.loads(response)
 
-        print_data(response_data)
+        log.debug("Response data: %s", response_data)
 
         if response_data.get("id") == self.message_id:
             return response_data.get("status") == 200

--- a/python-sdk/hibachi_xyz/env_setup.py
+++ b/python-sdk/hibachi_xyz/env_setup.py
@@ -1,17 +1,20 @@
+import logging
 import os
 from pathlib import Path
 
 from dotenv import load_dotenv
+
+log = logging.getLogger(__name__)
 
 
 def setup_environment():
     # Load the .env file if it exists
     env_file_path = Path(".env")
     if env_file_path.exists():
-        print("Loading environment variables from .env file")
+        log.info("Loading environment variables from .env file")
         load_dotenv()  # This loads variables from .env file (if it exists)
     else:
-        print(".env file not found. Falling back to Bash Environment variables.")
+        log.info(".env file not found. Falling back to Bash Environment variables.")
 
     # Use a default environment if no environment is passed
     environment = os.getenv(
@@ -19,7 +22,7 @@ def setup_environment():
     ).lower()  # Default to 'production' if not passed
 
     # Print out the environment for debugging purposes
-    print(f"Using {environment} environment")
+    log.info("Using %s environment", environment)
 
     # Dynamically load environment variables based on the environment
     api_endpoint = os.environ.get(

--- a/python-sdk/hibachi_xyz/helpers.py
+++ b/python-sdk/hibachi_xyz/helpers.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 from typing import Dict, TypeVar, Union, Any, Callable
 
 from hibachi_xyz.executors.interface import WsConnection
@@ -10,6 +11,8 @@ from dataclasses import asdict
 from decimal import Decimal
 from functools import lru_cache
 import inspect
+
+log = logging.getLogger(__name__)
 
 
 DEFAULT_API_URL: str = "https://api.hibachi.xyz"
@@ -64,8 +67,9 @@ async def connect_with_retry(
                     f"Failed to connect after {max_retries} attempts: {str(e)}"
                 )
 
-            print(
-                f"Connection attempt {retry_count} failed: {str(e)}. Retrying in {retry_delay} seconds..."
+            log.warning(
+                "Connection attempt %d failed: %s. Retrying in %d seconds...",
+                retry_count, str(e), retry_delay
             )
             await asyncio.sleep(retry_delay)
             retry_delay *= 2  # Exponential backoff

--- a/python-sdk/poetry.lock
+++ b/python-sdk/poetry.lock
@@ -293,12 +293,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "extra == \"dev\" and sys_platform == \"win32\" or platform_system == \"Windows\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "colorful"
@@ -709,10 +709,9 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 name = "iniconfig"
 version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"dev\""
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -839,16 +838,99 @@ files = [
 ]
 
 [[package]]
+name = "mypy"
+version = "1.18.2"
+description = "Optional static typing for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main", "dev"]
+files = [
+    {file = "mypy-1.18.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eab0cf6294dafe397c261a75f96dc2c31bffe3b944faa24db5def4e2b0f77c"},
+    {file = "mypy-1.18.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:7a780ca61fc239e4865968ebc5240bb3bf610ef59ac398de9a7421b54e4a207e"},
+    {file = "mypy-1.18.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:448acd386266989ef11662ce3c8011fd2a7b632e0ec7d61a98edd8e27472225b"},
+    {file = "mypy-1.18.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f9e171c465ad3901dc652643ee4bffa8e9fef4d7d0eece23b428908c77a76a66"},
+    {file = "mypy-1.18.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:592ec214750bc00741af1f80cbf96b5013d81486b7bb24cb052382c19e40b428"},
+    {file = "mypy-1.18.2-cp310-cp310-win_amd64.whl", hash = "sha256:7fb95f97199ea11769ebe3638c29b550b5221e997c63b14ef93d2e971606ebed"},
+    {file = "mypy-1.18.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:807d9315ab9d464125aa9fcf6d84fde6e1dc67da0b6f80e7405506b8ac72bc7f"},
+    {file = "mypy-1.18.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:776bb00de1778caf4db739c6e83919c1d85a448f71979b6a0edd774ea8399341"},
+    {file = "mypy-1.18.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1379451880512ffce14505493bd9fe469e0697543717298242574882cf8cdb8d"},
+    {file = "mypy-1.18.2-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1331eb7fd110d60c24999893320967594ff84c38ac6d19e0a76c5fd809a84c86"},
+    {file = "mypy-1.18.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ca30b50a51e7ba93b00422e486cbb124f1c56a535e20eff7b2d6ab72b3b2e37"},
+    {file = "mypy-1.18.2-cp311-cp311-win_amd64.whl", hash = "sha256:664dc726e67fa54e14536f6e1224bcfce1d9e5ac02426d2326e2bb4e081d1ce8"},
+    {file = "mypy-1.18.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:33eca32dd124b29400c31d7cf784e795b050ace0e1f91b8dc035672725617e34"},
+    {file = "mypy-1.18.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a3c47adf30d65e89b2dcd2fa32f3aeb5e94ca970d2c15fcb25e297871c8e4764"},
+    {file = "mypy-1.18.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5d6c838e831a062f5f29d11c9057c6009f60cb294fea33a98422688181fe2893"},
+    {file = "mypy-1.18.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01199871b6110a2ce984bde85acd481232d17413868c9807e95c1b0739a58914"},
+    {file = "mypy-1.18.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a2afc0fa0b0e91b4599ddfe0f91e2c26c2b5a5ab263737e998d6817874c5f7c8"},
+    {file = "mypy-1.18.2-cp312-cp312-win_amd64.whl", hash = "sha256:d8068d0afe682c7c4897c0f7ce84ea77f6de953262b12d07038f4d296d547074"},
+    {file = "mypy-1.18.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:07b8b0f580ca6d289e69209ec9d3911b4a26e5abfde32228a288eb79df129fcc"},
+    {file = "mypy-1.18.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:ed4482847168439651d3feee5833ccedbf6657e964572706a2adb1f7fa4dfe2e"},
+    {file = "mypy-1.18.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3ad2afadd1e9fea5cf99a45a822346971ede8685cc581ed9cd4d42eaf940986"},
+    {file = "mypy-1.18.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a431a6f1ef14cf8c144c6b14793a23ec4eae3db28277c358136e79d7d062f62d"},
+    {file = "mypy-1.18.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7ab28cc197f1dd77a67e1c6f35cd1f8e8b73ed2217e4fc005f9e6a504e46e7ba"},
+    {file = "mypy-1.18.2-cp313-cp313-win_amd64.whl", hash = "sha256:0e2785a84b34a72ba55fb5daf079a1003a34c05b22238da94fcae2bbe46f3544"},
+    {file = "mypy-1.18.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:62f0e1e988ad41c2a110edde6c398383a889d95b36b3e60bcf155f5164c4fdce"},
+    {file = "mypy-1.18.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8795a039bab805ff0c1dfdb8cd3344642c2b99b8e439d057aba30850b8d3423d"},
+    {file = "mypy-1.18.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6ca1e64b24a700ab5ce10133f7ccd956a04715463d30498e64ea8715236f9c9c"},
+    {file = "mypy-1.18.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d924eef3795cc89fecf6bedc6ed32b33ac13e8321344f6ddbf8ee89f706c05cb"},
+    {file = "mypy-1.18.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20c02215a080e3a2be3aa50506c67242df1c151eaba0dcbc1e4e557922a26075"},
+    {file = "mypy-1.18.2-cp314-cp314-win_amd64.whl", hash = "sha256:749b5f83198f1ca64345603118a6f01a4e99ad4bf9d103ddc5a3200cc4614adf"},
+    {file = "mypy-1.18.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:25a9c8fb67b00599f839cf472713f54249a62efd53a54b565eb61956a7e3296b"},
+    {file = "mypy-1.18.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2b9c7e284ee20e7598d6f42e13ca40b4928e6957ed6813d1ab6348aa3f47133"},
+    {file = "mypy-1.18.2-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6985ed057513e344e43a26cc1cd815c7a94602fb6a3130a34798625bc2f07b6"},
+    {file = "mypy-1.18.2-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22f27105f1525ec024b5c630c0b9f36d5c1cc4d447d61fe51ff4bd60633f47ac"},
+    {file = "mypy-1.18.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:030c52d0ea8144e721e49b1f68391e39553d7451f0c3f8a7565b59e19fcb608b"},
+    {file = "mypy-1.18.2-cp39-cp39-win_amd64.whl", hash = "sha256:aa5e07ac1a60a253445797e42b8b2963c9675563a94f11291ab40718b016a7a0"},
+    {file = "mypy-1.18.2-py3-none-any.whl", hash = "sha256:22a1748707dd62b58d2ae53562ffc4d7f8bcc727e8ac7cbc69c053ddc874d47e"},
+    {file = "mypy-1.18.2.tar.gz", hash = "sha256:06a398102a5f203d7477b2923dda3634c36727fa5c237d8f859ef90c42a9924b"},
+]
+
+[package.dependencies]
+mypy_extensions = ">=1.0.0"
+pathspec = ">=0.9.0"
+typing_extensions = ">=4.6.0"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+faster-cache = ["orjson"]
+install-types = ["pip"]
+mypyc = ["setuptools (>=50)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.1.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+optional = false
+python-versions = ">=3.8"
+groups = ["main", "dev"]
+files = [
+    {file = "mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505"},
+    {file = "mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558"},
+]
+
+[[package]]
 name = "packaging"
 version = "25.0"
 description = "Core utilities for Python packages"
-optional = true
+optional = false
 python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"dev\""
+groups = ["main", "dev"]
 files = [
     {file = "packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484"},
     {file = "packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f"},
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+optional = false
+python-versions = ">=3.8"
+groups = ["main", "dev"]
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 
 [[package]]
@@ -882,10 +964,9 @@ pip = ">=24.2"
 name = "pluggy"
 version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"dev\""
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -1159,7 +1240,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -1172,10 +1253,9 @@ windows-terminal = ["colorama (>=0.4.6)"]
 name = "pytest"
 version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"dev\""
+groups = ["main", "dev"]
 files = [
     {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
     {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
@@ -1195,10 +1275,9 @@ dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests
 name = "pytest-asyncio"
 version = "1.2.0"
 description = "Pytest support for asyncio"
-optional = true
+optional = false
 python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"dev\""
+groups = ["main", "dev"]
 files = [
     {file = "pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99"},
     {file = "pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57"},
@@ -1215,10 +1294,9 @@ testing = ["coverage (>=6.2)", "hypothesis (>=5.7.1)"]
 name = "pytest-timeout"
 version = "2.4.0"
 description = "pytest plugin to abort hanging tests"
-optional = true
+optional = false
 python-versions = ">=3.7"
-groups = ["main"]
-markers = "extra == \"dev\""
+groups = ["main", "dev"]
 files = [
     {file = "pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2"},
     {file = "pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a"},
@@ -1307,7 +1385,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -1545,9 +1623,9 @@ multidict = ">=4.0"
 propcache = ">=0.2.1"
 
 [extras]
-dev = ["pytest", "pytest-asyncio", "pytest-timeout"]
+dev = ["mypy", "pytest", "pytest-asyncio", "pytest-timeout"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<4"
-content-hash = "fd8fa31e8b2fa6533e1a0449007122f7cd3a7fb34e9f7afa3c01214a199815f2"
+content-hash = "f720fa1fcddf938f3a3e4a8b4c8668d643244362201d2b091620de150c753fca"

--- a/python-sdk/pyproject.toml
+++ b/python-sdk/pyproject.toml
@@ -29,14 +29,14 @@ dev = [
   "pytest",
   "pytest-asyncio",
   "pytest-timeout",
+  "mypy",
 ]
 
-[tool.poetry.extras]
-dev = [
-  "pytest",
-  "pytest-asyncio",
-  "pytest-timeout",
-]
+[tool.poetry.group.dev.dependencies]
+pytest = "*"
+pytest-asyncio = "*"
+pytest-timeout = "*"
+mypy = "*"
 
 [project.urls]
 Homepage = "https://github.com/hibachi-xyz/yule-os"


### PR DESCRIPTION
# Content
- Replaced `print` usage with `logging` module calls
- Replaced f-string usage in these calls with %-interpolation as is optimal for the logging module
- Added mypy support + fix dev dependency classification for poetry

# Testing
- py compile works
- existing tests pass

