### PR TITLE
Tick size helpers and validation

### DIFF
--- a/python/examples/example_rest_api.py
+++ b/python/examples/example_rest_api.py
@@ -5,6 +5,7 @@ from hibachi_xyz import (
     TWAPConfig,
     TWAPQuantityMode,
     UpdateOrder,
+    round_price_to_tick,
 )
 from hibachi_xyz.env_setup import setup_environment
 from hibachi_xyz.types import (
@@ -234,16 +235,21 @@ def example_auth_rest_api():
     # Market Order Placed: Nonce: 1750928720123123, Order ID: 588745218831456123
     print(f"Market Order Placed: Nonce: {nonce}, Order ID: {order_id}")
 
-    # Advanced Order
+    # Advanced Order — prices must be aligned to the contract's tick size.
+    # Use round_price_to_tick() to snap prices to the nearest valid increment.
+    tick_size = hibachi.get_tick_size("BTC/USDT-P")
+    limit_price = round_price_to_tick(float(prices.markPrice), tick_size)
+    trigger_price = round_price_to_tick(float(prices.markPrice) * 0.95, tick_size)
+
     (nonce, order_id) = hibachi.place_limit_order(
         symbol="BTC/USDT-P",
         quantity=0.0001,
-        price=float(prices.markPrice),
+        price=limit_price,
         side=Side.BID,
         max_fees_percent=float(exch_info.feeConfig.tradeTakerFeeRate) * 2.0,
-        trigger_price=float(prices.markPrice) * 0.95,
+        trigger_price=trigger_price,
     )
-    print(f"Market Order Placed: Nonce: {nonce}, Order ID: {order_id}")
+    print(f"Limit Order Placed: Nonce: {nonce}, Order ID: {order_id}")
 
     # Get Order Details
     # Order(

--- a/python/hibachi_xyz/__init__.py
+++ b/python/hibachi_xyz/__init__.py
@@ -117,6 +117,9 @@ from hibachi_xyz.types import (  # type: ignore[attr-defined]
     WithdrawalLimit,
     WithdrawRequest,
     WithdrawResponse,
+    check_tick_size,
+    round_price_to_tick,
+    round_quantity_to_step,
 )
 
 log = logging.getLogger(__name__)
@@ -247,4 +250,7 @@ __all__ = [
     "__version__",
     "print_data",
     "HibachiApiError",
+    "check_tick_size",
+    "round_price_to_tick",
+    "round_quantity_to_step",
 ]

--- a/python/hibachi_xyz/api.py
+++ b/python/hibachi_xyz/api.py
@@ -99,6 +99,7 @@ from hibachi_xyz.types import (
     WithdrawalLimit,
     WithdrawRequest,
     WithdrawResponse,
+    check_tick_size,
     deserialize_batch_response_order,
     full_precision_string,
     numeric_to_decimal,
@@ -1919,6 +1920,28 @@ class HibachiApiClient:
 
         return contract
 
+    def get_tick_size(self, symbol: str) -> Decimal:
+        """Get the tick size (minimum price increment) for a symbol.
+
+        Args:
+            symbol: The trading symbol (e.g., "BTC/USDT-P")
+
+        Returns:
+            Decimal: The tick size for the contract
+        """
+        return Decimal(self.__get_contract(symbol).tickSize)
+
+    def get_step_size(self, symbol: str) -> Decimal:
+        """Get the step size (minimum quantity increment) for a symbol.
+
+        Args:
+            symbol: The trading symbol (e.g., "BTC/USDT-P")
+
+        Returns:
+            Decimal: The step size for the contract
+        """
+        return Decimal(self.__get_contract(symbol).stepSize)
+
     def __ensure_contract_listed(self, symbol: str) -> None:
         """Validate that a trading symbol is listed on the exchange.
 
@@ -2074,6 +2097,10 @@ class HibachiApiClient:
 
         """
         contract = self.__get_contract(symbol)
+        if price is not None:
+            check_tick_size(price, contract.tickSize)
+        if trigger_price is not None:
+            check_tick_size(trigger_price, contract.tickSize)
         payload = self.__create_or_update_order_payload(
             contract, nonce, quantity, side, max_fees_percent, price
         )
@@ -2143,6 +2170,10 @@ class HibachiApiClient:
 
         """
         contract = self.__get_contract(symbol)
+        if price is not None:
+            check_tick_size(price, contract.tickSize)
+        if trigger_price is not None:
+            check_tick_size(trigger_price, contract.tickSize)
         payload = self.__create_or_update_order_payload(
             contract, nonce, quantity, side, max_fees_percent, price
         )

--- a/python/hibachi_xyz/api_ws_trade.py
+++ b/python/hibachi_xyz/api_ws_trade.py
@@ -33,6 +33,7 @@ from hibachi_xyz.types import (
     JsonObject,
     Nonce,
     Order,
+    OrderFlags,
     OrderPlaceParams,
     OrdersBatchParams,
     OrdersStatusResponse,
@@ -191,6 +192,8 @@ class HibachiWSTradeClient:
             price=params.price,
             creation_deadline=params.creation_deadline,
             twap_config=params.twap_config,
+            order_flags=OrderFlags(params.orderFlags) if params.orderFlags else None,
+            trigger_direction=params.trigger_direction,
         )
 
         prepare_packet["accountId"] = self.account_id

--- a/python/hibachi_xyz/types.py
+++ b/python/hibachi_xyz/types.py
@@ -56,6 +56,83 @@ WsEventHandler: TypeAlias = Callable[[Json], Coroutine[None, None, None]]
 DECIMAL_PATTERN = re.compile(r"^\d+(\.\d+)?$")
 
 
+def round_price_to_tick(
+    price: HibachiNumericInput, tick_size: HibachiNumericInput
+) -> Decimal:
+    """Round a price to the nearest multiple of the tick size.
+
+    Args:
+        price: The price to round (Decimal, str, float, or int)
+        tick_size: The tick size (Decimal, str, float, or int)
+
+    Returns:
+        Decimal: The price rounded to the nearest tick size multiple
+
+    Raises:
+        ValidationError: If the price or tick_size is invalid, or tick_size is not positive
+
+    Example:
+        >>> round_price_to_tick(100.123, "0.01")
+        Decimal('100.12')
+        >>> round_price_to_tick("50.0055", Decimal("0.001"))
+        Decimal('50.006')
+    """
+    p = numeric_to_decimal(price)
+    tick = numeric_to_decimal(tick_size)
+    if tick <= 0:
+        raise ValidationError(f"Tick size must be positive, got: {tick_size}")
+    return (p / tick).quantize(Decimal("1")) * tick
+
+
+def round_quantity_to_step(
+    quantity: HibachiNumericInput, step_size: HibachiNumericInput
+) -> Decimal:
+    """Round a quantity down to the nearest multiple of the step size.
+
+    Uses ROUND_DOWN to avoid exceeding the intended quantity.
+
+    Args:
+        quantity: The quantity to round (Decimal, str, float, or int)
+        step_size: The step size (Decimal, str, float, or int)
+
+    Returns:
+        Decimal: The quantity rounded down to the nearest step size multiple
+
+    Raises:
+        ValidationError: If the quantity or step_size is invalid, or step_size is not positive
+
+    Example:
+        >>> round_quantity_to_step(1.23456789, "0.00000001")
+        Decimal('1.23456789')
+    """
+    from decimal import ROUND_DOWN
+
+    q = numeric_to_decimal(quantity)
+    step = numeric_to_decimal(step_size)
+    if step <= 0:
+        raise ValidationError(f"Step size must be positive, got: {step_size}")
+    return (q / step).quantize(Decimal("1"), rounding=ROUND_DOWN) * step
+
+
+def check_tick_size(price: HibachiNumericInput, tick_size: HibachiNumericInput) -> None:
+    """Validate that a price is a multiple of the tick size.
+
+    Args:
+        price: The price to validate
+        tick_size: The tick size (Decimal, str, float, or int)
+
+    Raises:
+        ValidationError: If the price is not a multiple of the tick size, or tick_size is not positive
+    """
+    p = numeric_to_decimal(price)
+    tick = numeric_to_decimal(tick_size)
+    if tick <= 0:
+        raise ValidationError(f"Tick size must be positive, got: {tick_size}")
+    remainder = p % tick
+    if remainder != Decimal("0"):
+        raise ValidationError(f"Price {p} is not a multiple of tick size {tick_size}")
+
+
 def full_precision_string(n: HibachiNumericInput) -> str:
     """Convert a numeric input to a full precision string representation."""
     if isinstance(n, str):

--- a/python/tests/unit/test_tick_size.py
+++ b/python/tests/unit/test_tick_size.py
@@ -64,7 +64,7 @@ class TestRoundPriceToTick:
             round_price_to_tick("100.12345", "-0.01")
 
     def test_simulates_mark_price_offset(self):
-        """Simulate Ymir-style price generation: mark * (1 + delta)."""
+        """Simulate price generation from mark price with small offset."""
         mark = Decimal("2234")
         tick = "0.01"
         for i in range(1, 20):

--- a/python/tests/unit/test_tick_size.py
+++ b/python/tests/unit/test_tick_size.py
@@ -1,0 +1,131 @@
+"""Tests for tick size and step size rounding and validation utilities."""
+
+from decimal import Decimal
+
+import pytest
+
+from hibachi_xyz.errors import ValidationError
+from hibachi_xyz.types import (
+    check_tick_size,
+    round_price_to_tick,
+    round_quantity_to_step,
+)
+
+
+class TestRoundPriceToTick:
+    """Tests for round_price_to_tick utility."""
+
+    def test_already_aligned(self):
+        result = round_price_to_tick("100.01", "0.01")
+        assert result == Decimal("100.01")
+
+    def test_rounds_nearest(self):
+        result = round_price_to_tick("100.005", "0.01")
+        assert result == Decimal("100.00") or result == Decimal("100.01")
+
+    def test_rounds_down(self):
+        result = round_price_to_tick("100.004", "0.01")
+        assert result == Decimal("100.00")
+
+    def test_rounds_up(self):
+        result = round_price_to_tick("100.006", "0.01")
+        assert result == Decimal("100.01")
+
+    def test_float_input(self):
+        result = round_price_to_tick(100.123, "0.01")
+        assert result == Decimal("100.12")
+
+    def test_int_input(self):
+        result = round_price_to_tick(100, "0.01")
+        assert result == Decimal("100.00")
+
+    def test_decimal_input(self):
+        result = round_price_to_tick(Decimal("100.123"), "0.01")
+        assert result == Decimal("100.12")
+
+    def test_btc_tick_size(self):
+        result = round_price_to_tick("71286.05", "0.1")
+        assert result == Decimal("71286.0") or result == Decimal("71286.1")
+
+    def test_sol_tick_size(self):
+        result = round_price_to_tick("84.5001", "0.001")
+        assert result == Decimal("84.500")
+
+    def test_sui_tick_size(self):
+        result = round_price_to_tick("0.962423", "0.00001")
+        assert result == Decimal("0.96242")
+
+    def test_zero_tick_size_raises(self):
+        with pytest.raises(ValidationError, match="must be positive"):
+            round_price_to_tick("100.12345", "0")
+
+    def test_negative_tick_size_raises(self):
+        with pytest.raises(ValidationError):
+            round_price_to_tick("100.12345", "-0.01")
+
+    def test_simulates_mark_price_offset(self):
+        """Simulate Ymir-style price generation: mark * (1 + delta)."""
+        mark = Decimal("2234")
+        tick = "0.01"
+        for i in range(1, 20):
+            delta = Decimal(str(i)) * Decimal("0.0001")
+            price = mark * (1 + delta)
+            rounded = round_price_to_tick(price, tick)
+            # Must pass validation
+            check_tick_size(rounded, tick)
+
+    def test_mid_price_half_tick(self):
+        """Mid price (bid+ask)/2 is often a half-tick."""
+        bid = Decimal("100.01")
+        ask = Decimal("100.02")
+        mid = (bid + ask) / 2  # 100.015
+        result = round_price_to_tick(mid, "0.01")
+        check_tick_size(result, "0.01")
+        assert result == Decimal("100.02")
+
+
+class TestRoundQuantityToStep:
+    """Tests for round_quantity_to_step utility."""
+
+    def test_already_aligned(self):
+        result = round_quantity_to_step("1.0", "0.000000001")
+        assert result == Decimal("1.000000000")
+
+    def test_rounds_down(self):
+        """Quantity should round DOWN to avoid exceeding intended size."""
+        result = round_quantity_to_step("1.9999999999", "0.000000001")
+        assert result == Decimal("1.999999999")
+
+    def test_float_input(self):
+        result = round_quantity_to_step(0.123456789, "0.00000001")
+        assert result == Decimal("0.12345678")
+
+    def test_zero_step_raises(self):
+        with pytest.raises(ValidationError, match="must be positive"):
+            round_quantity_to_step("1.23456", "0")
+
+
+class TestCheckTickSize:
+    """Tests for check_tick_size validation."""
+
+    def test_valid_price(self):
+        check_tick_size("100.01", "0.01")  # Should not raise
+
+    def test_invalid_price(self):
+        with pytest.raises(ValidationError, match="not a multiple of tick size"):
+            check_tick_size("100.001", "0.01")
+
+    def test_zero_tick_size_raises(self):
+        with pytest.raises(ValidationError, match="must be positive"):
+            check_tick_size("100.12345", "0")
+
+    def test_trigger_price_validation(self):
+        with pytest.raises(ValidationError, match="not a multiple of tick size"):
+            check_tick_size("1.005", "0.01")
+
+    def test_decimal_input(self):
+        check_tick_size(Decimal("100.01"), "0.01")  # Should not raise
+
+    def test_decimal_input_invalid(self):
+        with pytest.raises(ValidationError):
+            check_tick_size(Decimal("100.001"), "0.01")


### PR DESCRIPTION
**Breaking API Change**

Orders with prices not aligned to the contract's tick size are now rejected client-side with `ValidationError`. 
Use `round_price_to_tick()` to snap prices to the nearest valid increment before submission.

**Example **

```
    # Advanced Order — prices must be aligned to the contract's tick size.
    # Use round_price_to_tick() to snap prices to the nearest valid increment.
    tick_size = hibachi.get_tick_size("BTC/USDT-P")
    limit_price = round_price_to_tick(float(prices.markPrice), tick_size)
    trigger_price = round_price_to_tick(float(prices.markPrice) * 0.95, tick_size)

    (nonce, order_id) = hibachi.place_limit_order(
        symbol="BTC/USDT-P",
        quantity=0.0001,
        price=limit_price,
        side=Side.BID,
        max_fees_percent=float(exch_info.feeConfig.tradeTakerFeeRate) * 2.0,
        trigger_price=trigger_price,
    )
```