### PR TITLE
tpsl bug fixes

### DIFF
--- a/python/hibachi_xyz/api.py
+++ b/python/hibachi_xyz/api.py
@@ -1245,6 +1245,7 @@ class HibachiApiClient:
         creation_deadline: HibachiNumericInput | None = None,
         order_flags: OrderFlags | None = None,
         tpsl: TPSLConfig | None = None,
+        trigger_direction: TriggerDirection | None = None,
     ) -> tuple[Nonce, OrderId]:
         """Place a market order.
 
@@ -1261,12 +1262,15 @@ class HibachiApiClient:
             creation_deadline: Deadline in seconds for order creation (optional)
             order_flags: Additional order flags (optional)
             tpsl: Take-profit/stop-loss configuration (optional)
+            trigger_direction: Direction for trigger activation — HIGH or LOW (optional)
 
         Returns:
             tuple[Nonce, OrderId]: Tuple containing the nonce (defaults to current epoch timestamp in μs) and order ID
 
         Raises:
-            ValueError: If both twap_config and trigger_price are set, or if twap_config and tpsl are set
+            ValueError: If both twap_config and trigger_price are set, or if twap_config and tpsl are set,
+                or if trigger_price and tpsl are set together (the exchange does not allow a parent order
+                to also be a trigger order)
             DeserializationError: If the API response cannot be parsed
 
         Example:
@@ -1276,6 +1280,7 @@ class HibachiApiClient:
                 (nonce, order_id) = client.place_market_order("BTC/USDT-P", 0.0001, Side.SELL, max_fees_percent)
                 (nonce, order_id) = client.place_market_order("BTC/USDT-P", 0.0001, Side.BID, max_fees_percent, creation_deadline=2)
                 (nonce, order_id) = client.place_market_order("BTC/USDT-P", 0.0001, Side.ASK, max_fees_percent, trigger_price=1_000_000)
+                (nonce, order_id) = client.place_market_order("BTC/USDT-P", 0.0001, Side.ASK, max_fees_percent, trigger_price=1_000_000, trigger_direction=TriggerDirection.LOW)
                 (nonce, order_id) = client.place_market_order("SOL/USDT-P", 1, Side.BID, max_fees_percent, twap_config=twap_config)
 
         Endpoint:
@@ -1295,6 +1300,11 @@ class HibachiApiClient:
         if twap_config is not None and tpsl is not None:
             raise ValidationError("Can not set tpsl for TWAP order")
 
+        if tpsl is not None and len(tpsl.legs) > 0 and trigger_price is not None:
+            raise ValidationError(
+                "Can not set trigger price on a parent order with TPSL"
+            )
+
         quantity = numeric_to_decimal(quantity)
         max_fees_percent = numeric_to_decimal(max_fees_percent)
         trigger_price = numeric_to_decimal(trigger_price)
@@ -1307,7 +1317,6 @@ class HibachiApiClient:
                 quantity=quantity,
                 side=side,
                 max_fees_percent=max_fees_percent,
-                trigger_price=trigger_price,
                 creation_deadline=creation_deadline,
                 order_flags=order_flags,
                 tpsl=tpsl,
@@ -1325,6 +1334,7 @@ class HibachiApiClient:
             creation_deadline,
             twap_config=twap_config,
             order_flags=order_flags,
+            trigger_direction=trigger_direction,
         )
         request_data["accountId"] = self.account_id
         response = self.__send_authorized_request(
@@ -1348,6 +1358,7 @@ class HibachiApiClient:
         creation_deadline: HibachiNumericInput | None = None,
         order_flags: OrderFlags | None = None,
         tpsl: TPSLConfig | None = None,
+        trigger_direction: TriggerDirection | None = None,
     ) -> tuple[Nonce, OrderId]:
         """Place a limit order.
 
@@ -1364,11 +1375,14 @@ class HibachiApiClient:
             creation_deadline: Deadline in seconds for order creation (optional)
             order_flags: Additional order flags (optional)
             tpsl: Take-profit/stop-loss configuration (optional)
+            trigger_direction: Direction for trigger activation — HIGH or LOW (optional)
 
         Returns:
             tuple[Nonce, OrderId]: Tuple containing the nonce (defaults to current epoch timestamp in μs) and order ID
 
         Raises:
+            ValueError: If trigger_price and tpsl are set together (the exchange does not allow a parent
+                order to also be a trigger order)
             DeserializationError: If the API response cannot be parsed
 
         Example:
@@ -1378,6 +1392,7 @@ class HibachiApiClient:
                 (nonce, order_id) = client.place_limit_order("BTC/USDT-P", 0.0001, 80_000, Side.SELL, max_fees_percent)
                 (nonce, order_id) = client.place_limit_order("BTC/USDT-P", 0.0001, 80_000, Side.BID, max_fees_percent, creation_deadline=2)
                 (nonce, order_id) = client.place_limit_order("BTC/USDT-P", 0.0001, 1_001_000, Side.ASK, max_fees_percent, trigger_price=1_000_000)
+                (nonce, order_id) = client.place_limit_order("BTC/USDT-P", 0.0001, 1_001_000, Side.ASK, max_fees_percent, trigger_price=1_000_000, trigger_direction=TriggerDirection.LOW)
                 (nonce, limit_order_id) = client.place_limit_order("BTC/USDT-P", 0.001, 6_000, Side.BID, max_fees_percent)
 
         Endpoint:
@@ -1390,6 +1405,11 @@ class HibachiApiClient:
             side = Side.BID
         elif side == Side.SELL:
             side = Side.ASK
+
+        if tpsl is not None and len(tpsl.legs) > 0 and trigger_price is not None:
+            raise ValidationError(
+                "Can not set trigger price on a parent order with TPSL"
+            )
 
         price = numeric_to_decimal(price)
         quantity = numeric_to_decimal(quantity)
@@ -1404,7 +1424,6 @@ class HibachiApiClient:
                 quantity=quantity,
                 side=side,
                 max_fees_percent=max_fees_percent,
-                trigger_price=trigger_price,
                 creation_deadline=creation_deadline,
                 order_flags=order_flags,
                 tpsl=tpsl,
@@ -1421,6 +1440,7 @@ class HibachiApiClient:
             price,
             creation_deadline,
             order_flags=order_flags,
+            trigger_direction=trigger_direction,
         )
         request_data["accountId"] = self.account_id
         response = self.__send_authorized_request(
@@ -1441,13 +1461,13 @@ class HibachiApiClient:
         side: Side,
         max_fees_percent: Decimal,
         tpsl: TPSLConfig,
-        trigger_price: Decimal | None = None,
         creation_deadline: Decimal | None = None,
         order_flags: OrderFlags | None = None,
     ) -> tuple[Nonce, OrderId]:
         """Place a parent order with take-profit/stop-loss child orders.
 
         Creates a parent order along with its configured TP/SL child orders in a single batch.
+        The parent order must not be a trigger order — the exchange rejects that combination.
 
         Args:
             symbol: Trading symbol
@@ -1456,7 +1476,6 @@ class HibachiApiClient:
             side: Order side (BID/ASK)
             max_fees_percent: Maximum fees as percentage
             tpsl: Take-profit/stop-loss configuration
-            trigger_price: Trigger price for parent order (optional)
             creation_deadline: Deadline for order creation (optional)
             order_flags: Additional order flags (optional)
 
@@ -1473,7 +1492,6 @@ class HibachiApiClient:
             quantity=quantity,
             side=side,
             price=price,
-            trigger_price=trigger_price,
             creation_deadline=creation_deadline,
             order_flags=order_flags,
             max_fees_percent=max_fees_percent,

--- a/python/hibachi_xyz/types.py
+++ b/python/hibachi_xyz/types.py
@@ -439,7 +439,7 @@ class TPSLConfig:
                     side=side,
                     quantity=leg.quantity or numeric_to_decimal(parent_quantity),
                     max_fees_percent=numeric_to_decimal(max_fees_percent),
-                    trigger_price=numeric_to_decimal(max_fees_percent),
+                    trigger_price=leg.price,
                     trigger_direction=trigger_direction,
                     parent_order=OrderIdVariant.from_nonce(parent_nonce),
                     order_flags=OrderFlags.ReduceOnly,

--- a/python/tests/unit/http/post/test_place_limit_order.py
+++ b/python/tests/unit/http/post/test_place_limit_order.py
@@ -1,8 +1,8 @@
 import pytest
 
-from hibachi_xyz.errors import DeserializationError
+from hibachi_xyz.errors import DeserializationError, ValidationError
 from hibachi_xyz.executors.interface import HttpResponse
-from hibachi_xyz.types import FutureContract, Side
+from hibachi_xyz.types import FutureContract, Side, TPSLConfig, TriggerDirection
 from tests.mock_executors import MockSuccessfulOutput
 from tests.unit.conftest import load_json_all_cases
 
@@ -101,3 +101,103 @@ def test_place_limit_order_deserialization_error(mock_http_client):
         )
 
     assert "Received invalid" in str(exc_info.value)
+
+
+BTC_CONTRACT = FutureContract(
+    displayName="BTC/USDT Perps",
+    id=1,
+    initialMarginRate="0.066667",
+    maintenanceMarginRate="0.046667",
+    marketCloseTimestamp=None,
+    marketCreationTimestamp="1727701319.73488",
+    marketOpenTimestamp=None,
+    minNotional="1",
+    minOrderSize="0.000000001",
+    orderbookGranularities=["0.01", "0.1", "1"],
+    settlementDecimals=6,
+    settlementSymbol="USDT",
+    status="LIVE",
+    stepSize="0.000000001",
+    symbol="BTC/USDT-P",
+    tickSize="0.000001",
+    underlyingDecimals=8,
+    underlyingSymbol="BTC",
+)
+
+
+@pytest.mark.parametrize("direction", [TriggerDirection.HIGH, TriggerDirection.LOW])
+def test_place_limit_order_trigger_direction_included_in_request(
+    mock_http_client, direction
+):
+    client, mock_http = mock_http_client
+    client._future_contracts = {"BTC/USDT-P": BTC_CONTRACT}
+
+    captured = {}
+
+    mock_http.stage_output(
+        MockSuccessfulOutput(
+            output=HttpResponse(status=200, body={"orderId": 12345}),
+            call_validation=lambda call: captured.update({"body": call.arg_pack[2]})
+            or (
+                call.function_name == "send_authorized_request"
+                and call.arg_pack[0:2] == ("POST", "/trade/order")
+            ),
+        )
+    )
+
+    client.place_limit_order(
+        "BTC/USDT-P",
+        0.001,
+        85_000,
+        Side.SELL,
+        0.001,
+        trigger_price=85_000,
+        trigger_direction=direction,
+    )
+
+    assert captured["body"]["triggerDirection"] == direction.value
+
+
+def test_place_limit_order_trigger_direction_absent_when_not_provided(mock_http_client):
+    client, mock_http = mock_http_client
+    client._future_contracts = {"BTC/USDT-P": BTC_CONTRACT}
+
+    captured = {}
+
+    mock_http.stage_output(
+        MockSuccessfulOutput(
+            output=HttpResponse(status=200, body={"orderId": 12345}),
+            call_validation=lambda call: captured.update({"body": call.arg_pack[2]})
+            or (
+                call.function_name == "send_authorized_request"
+                and call.arg_pack[0:2] == ("POST", "/trade/order")
+            ),
+        )
+    )
+
+    client.place_limit_order(
+        "BTC/USDT-P", 0.001, 85_000, Side.SELL, 0.001, trigger_price=85_000
+    )
+
+    assert "triggerDirection" not in captured["body"]
+
+
+def test_place_limit_order_trigger_price_with_tpsl_raises(mock_http_client):
+    """The exchange rejects parent orders that are also trigger orders."""
+    client, mock_http = mock_http_client
+    client._future_contracts = {"BTC/USDT-P": BTC_CONTRACT}
+
+    tpsl = TPSLConfig().add_take_profit(price=90_000)
+    with pytest.raises(ValidationError) as exc_info:
+        client.place_limit_order(
+            "BTC/USDT-P",
+            0.001,
+            80_000,
+            Side.BUY,
+            0.001,
+            trigger_price=85_000,
+            tpsl=tpsl,
+        )
+
+    assert "trigger price" in str(exc_info.value).lower()
+    assert "tpsl" in str(exc_info.value).lower()

--- a/python/tests/unit/http/post/test_place_market_order.py
+++ b/python/tests/unit/http/post/test_place_market_order.py
@@ -6,6 +6,7 @@ from hibachi_xyz.types import (
     FutureContract,
     Side,
     TPSLConfig,
+    TriggerDirection,
     TWAPConfig,
     TWAPQuantityMode,
 )
@@ -140,3 +141,113 @@ def test_place_market_order_twap_with_tpsl(mock_http_client):
         )
 
     assert "Can not set tpsl for TWAP order" in str(exc_info.value)
+
+
+BTC_CONTRACT = FutureContract(
+    displayName="BTC/USDT Perps",
+    id=1,
+    initialMarginRate="0.066667",
+    maintenanceMarginRate="0.046667",
+    marketCloseTimestamp=None,
+    marketCreationTimestamp="1727701319.73488",
+    marketOpenTimestamp=None,
+    minNotional="1",
+    minOrderSize="0.000000001",
+    orderbookGranularities=["0.01", "0.1", "1"],
+    settlementDecimals=6,
+    settlementSymbol="USDT",
+    status="LIVE",
+    stepSize="0.000000001",
+    symbol="BTC/USDT-P",
+    tickSize="0.000001",
+    underlyingDecimals=8,
+    underlyingSymbol="BTC",
+)
+
+
+def _stage_market_order(mock_http, order_id=12345):
+    mock_http.stage_output(
+        MockSuccessfulOutput(
+            output=HttpResponse(status=200, body={"orderId": order_id}),
+            call_validation=lambda call: call.function_name == "send_authorized_request"
+            and call.arg_pack[0:2] == ("POST", "/trade/order"),
+        )
+    )
+
+
+@pytest.mark.parametrize("direction", [TriggerDirection.HIGH, TriggerDirection.LOW])
+def test_place_market_order_trigger_direction_included_in_request(
+    mock_http_client, direction
+):
+    client, mock_http = mock_http_client
+    client._future_contracts = {"BTC/USDT-P": BTC_CONTRACT}
+
+    captured = {}
+
+    mock_http.stage_output(
+        MockSuccessfulOutput(
+            output=HttpResponse(status=200, body={"orderId": 12345}),
+            call_validation=lambda call: captured.update({"body": call.arg_pack[2]})
+            or (
+                call.function_name == "send_authorized_request"
+                and call.arg_pack[0:2] == ("POST", "/trade/order")
+            ),
+        )
+    )
+
+    client.place_market_order(
+        "BTC/USDT-P",
+        0.001,
+        Side.BUY,
+        0.001,
+        trigger_price=85_000,
+        trigger_direction=direction,
+    )
+
+    assert captured["body"]["triggerDirection"] == direction.value
+
+
+def test_place_market_order_trigger_direction_absent_when_not_provided(
+    mock_http_client,
+):
+    client, mock_http = mock_http_client
+    client._future_contracts = {"BTC/USDT-P": BTC_CONTRACT}
+
+    captured = {}
+
+    mock_http.stage_output(
+        MockSuccessfulOutput(
+            output=HttpResponse(status=200, body={"orderId": 12345}),
+            call_validation=lambda call: captured.update({"body": call.arg_pack[2]})
+            or (
+                call.function_name == "send_authorized_request"
+                and call.arg_pack[0:2] == ("POST", "/trade/order")
+            ),
+        )
+    )
+
+    client.place_market_order(
+        "BTC/USDT-P", 0.001, Side.BUY, 0.001, trigger_price=85_000
+    )
+
+    assert "triggerDirection" not in captured["body"]
+
+
+def test_place_market_order_trigger_price_with_tpsl_raises(mock_http_client):
+    """The exchange rejects parent orders that are also trigger orders."""
+    client, mock_http = mock_http_client
+    client._future_contracts = {"BTC/USDT-P": BTC_CONTRACT}
+
+    tpsl = TPSLConfig().add_take_profit(price=90_000)
+    with pytest.raises(ValidationError) as exc_info:
+        client.place_market_order(
+            "BTC/USDT-P",
+            0.001,
+            Side.BUY,
+            0.001,
+            trigger_price=85_000,
+            tpsl=tpsl,
+        )
+
+    assert "trigger price" in str(exc_info.value).lower()
+    assert "tpsl" in str(exc_info.value).lower()

--- a/python/tests/unit/test_tpsl_config.py
+++ b/python/tests/unit/test_tpsl_config.py
@@ -1,0 +1,73 @@
+"""Tests for TPSLConfig._as_requests."""
+
+from decimal import Decimal
+
+from hibachi_xyz.types import Side, TPSLConfig, TriggerDirection
+
+
+class TestTPSLConfigAsRequests:
+    def _make_requests(self, tpsl, parent_side):
+        return tpsl._as_requests(
+            parent_symbol="BTC/USDT-P",
+            parent_quantity="0.001",
+            parent_side=parent_side,
+            parent_nonce=12345,
+            max_fees_percent="0.001",
+        )
+
+    def test_take_profit_trigger_price_matches_leg_price(self):
+        tpsl = TPSLConfig().add_take_profit(price=70000)
+        orders = self._make_requests(tpsl, Side.BID)
+        assert orders[0].trigger_price == Decimal("70000")
+
+    def test_stop_loss_trigger_price_matches_leg_price(self):
+        tpsl = TPSLConfig().add_stop_loss(price=40000)
+        orders = self._make_requests(tpsl, Side.BID)
+        assert orders[0].trigger_price == Decimal("40000")
+
+    def test_trigger_price_is_not_max_fees_percent(self):
+        tpsl = TPSLConfig().add_take_profit(price=70000)
+        orders = self._make_requests(tpsl, Side.BID)
+        assert orders[0].trigger_price != orders[0].max_fees_percent
+
+    def test_ask_take_profit_trigger_price_matches_leg_price(self):
+        tpsl = TPSLConfig().add_take_profit(price=40000)
+        orders = self._make_requests(tpsl, Side.ASK)
+        assert orders[0].trigger_price == Decimal("40000")
+
+    def test_ask_stop_loss_trigger_price_matches_leg_price(self):
+        tpsl = TPSLConfig().add_stop_loss(price=70000)
+        orders = self._make_requests(tpsl, Side.ASK)
+        assert orders[0].trigger_price == Decimal("70000")
+
+    def test_multiple_legs_each_get_correct_trigger_price(self):
+        tpsl = TPSLConfig().add_take_profit(price=70000).add_stop_loss(price=40000)
+        orders = self._make_requests(tpsl, Side.BID)
+        assert orders[0].trigger_price == Decimal("70000")
+        assert orders[1].trigger_price == Decimal("40000")
+
+    def test_ask_multiple_legs_each_get_correct_trigger_price(self):
+        tpsl = TPSLConfig().add_take_profit(price=40000).add_stop_loss(price=70000)
+        orders = self._make_requests(tpsl, Side.ASK)
+        assert orders[0].trigger_price == Decimal("40000")
+        assert orders[1].trigger_price == Decimal("70000")
+
+    def test_bid_parent_tp_uses_high_direction(self):
+        tpsl = TPSLConfig().add_take_profit(price=70000)
+        orders = self._make_requests(tpsl, Side.BID)
+        assert orders[0].trigger_direction == TriggerDirection.HIGH
+
+    def test_bid_parent_sl_uses_low_direction(self):
+        tpsl = TPSLConfig().add_stop_loss(price=40000)
+        orders = self._make_requests(tpsl, Side.BID)
+        assert orders[0].trigger_direction == TriggerDirection.LOW
+
+    def test_ask_parent_tp_uses_low_direction(self):
+        tpsl = TPSLConfig().add_take_profit(price=40000)
+        orders = self._make_requests(tpsl, Side.ASK)
+        assert orders[0].trigger_direction == TriggerDirection.LOW
+
+    def test_ask_parent_sl_uses_high_direction(self):
+        tpsl = TPSLConfig().add_stop_loss(price=70000)
+        orders = self._make_requests(tpsl, Side.ASK)
+        assert orders[0].trigger_direction == TriggerDirection.HIGH


### PR DESCRIPTION
## Fixes
1. pass `trigger_direction` to the internal `_create_order_request_data()` helper in `place_market_order()` and `place_limit_oder()`
2. add validation to prevent sending a parent order with trigger conditions since this will be rejected by the API backend
3. fix a copy-paste error for setting `trigger_price`