### PR TITLE
fix: enforce request timeouts and trigger price casing

### DIFF
--- a/python/hibachi_xyz/api.py
+++ b/python/hibachi_xyz/api.py
@@ -2223,7 +2223,7 @@ class HibachiApiClient:
             request["orderId"] = str(order_id)
         if trigger_price is not None:
             request["updatedTriggerPrice"] = full_precision_string(trigger_price)
-            request["trigger_price"] = full_precision_string(trigger_price)
+            request["triggerPrice"] = full_precision_string(trigger_price)
         if creation_deadline is not None:
             request["creationDeadline"] = absolute_creation_deadline(creation_deadline)
         if order_flags is not None:

--- a/python/hibachi_xyz/executors/requests.py
+++ b/python/hibachi_xyz/executors/requests.py
@@ -24,6 +24,8 @@ from hibachi_xyz.helpers import (
 )
 from hibachi_xyz.types import Json
 
+DEFAULT_TIMEOUT = 30.0
+
 
 class RequestsHttpExecutor(HttpExecutor):
     """HTTP executor implementation using requests.
@@ -36,6 +38,7 @@ class RequestsHttpExecutor(HttpExecutor):
         api_url: str = DEFAULT_API_URL,
         data_api_url: str = DEFAULT_DATA_API_URL,
         api_key: str | None = None,
+        timeout_seconds: float = DEFAULT_TIMEOUT,
     ):
         """Initialize the RequestsHttpExecutor with API configuration.
 
@@ -43,11 +46,13 @@ class RequestsHttpExecutor(HttpExecutor):
             api_url: The base URL for authenticated API requests. Defaults to DEFAULT_API_URL.
             data_api_url: The base URL for unauthenticated data API requests. Defaults to DEFAULT_DATA_API_URL.
             api_key: The API key for authenticated requests. Optional.
+            timeout_seconds: Timeout applied to each requests call, in seconds.
 
         """
         self.api_url = api_url
         self.data_api_url = data_api_url
         self.api_key = api_key
+        self.timeout_seconds = timeout_seconds
 
     @override
     def send_simple_request(self, path: str) -> HttpResponse:
@@ -70,12 +75,13 @@ class RequestsHttpExecutor(HttpExecutor):
             response = requests.get(
                 url,
                 headers={"Hibachi-Client": get_hibachi_client()},
+                timeout=self.timeout_seconds,
             )
         except BaseError:
             raise
         except requests.Timeout as e:
             raise TransportTimeoutError(
-                f"Request to {url} timed out", timeout_seconds=None
+                f"Request to {url} timed out", timeout_seconds=self.timeout_seconds
             ) from e
         except requests.ConnectionError as e:
             raise HttpConnectionError(f"Failed to connect to {url}", url=url) from e
@@ -116,12 +122,18 @@ class RequestsHttpExecutor(HttpExecutor):
                 "Hibachi-Client": get_hibachi_client(),
             }
 
-            response = requests.request(method, url, headers=headers, data=request_body)
+            response = requests.request(
+                method,
+                url,
+                headers=headers,
+                data=request_body,
+                timeout=self.timeout_seconds,
+            )
         except BaseError:
             raise
         except requests.Timeout as e:
             raise TransportTimeoutError(
-                f"{method} request to {url} timed out", timeout_seconds=None
+                f"{method} request to {url} timed out", timeout_seconds=self.timeout_seconds
             ) from e
         except requests.ConnectionError as e:
             raise HttpConnectionError(f"Failed to connect to {url}", url=url) from e

--- a/python/tests/test_requests_executor.py
+++ b/python/tests/test_requests_executor.py
@@ -1,0 +1,53 @@
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from hibachi_xyz.errors import TransportTimeoutError
+from hibachi_xyz.executors.requests import DEFAULT_TIMEOUT, RequestsHttpExecutor
+
+
+def test_simple_request_passes_configured_timeout() -> None:
+    response = Mock(status_code=200, content=b"{}")
+    executor = RequestsHttpExecutor(
+        data_api_url="https://data.example",
+        timeout_seconds=7.5,
+    )
+
+    with patch("requests.get", return_value=response) as request:
+        executor.send_simple_request("/health")
+
+    request.assert_called_once_with(
+        "https://data.example/health",
+        headers={"Hibachi-Client": request.call_args.kwargs["headers"]["Hibachi-Client"]},
+        timeout=7.5,
+    )
+
+
+def test_authorized_request_passes_default_timeout() -> None:
+    response = Mock(status_code=200, content=b"{}")
+    executor = RequestsHttpExecutor(
+        api_url="https://api.example",
+        api_key="test-key",
+    )
+
+    with patch("requests.request", return_value=response) as request:
+        executor.send_authorized_request("POST", "/orders", {"x": 1})
+
+    assert request.call_args.kwargs["timeout"] == DEFAULT_TIMEOUT
+    assert request.call_args.args[:2] == ("POST", "https://api.example/orders")
+
+
+@pytest.mark.parametrize("method", ["send_simple_request", "send_authorized_request"])
+def test_requests_timeout_is_translated(method: str) -> None:
+    executor = RequestsHttpExecutor(timeout_seconds=3.0)
+    patch_target = "requests.get" if method == "send_simple_request" else "requests.request"
+
+    with patch(patch_target, side_effect=requests.Timeout("timed out")):
+        with pytest.raises(TransportTimeoutError) as raised:
+            if method == "send_simple_request":
+                executor.send_simple_request("/health")
+            else:
+                executor.send_authorized_request("GET", "/health")
+
+    assert raised.value.timeout_seconds == 3.0


### PR DESCRIPTION
Addresses issues #47 and #48.

Changes:
- Send update_order triggerPrice using the API's camelCase field.
- - Add a configurable 30-second default timeout to both requests executor paths.
- - Preserve TransportTimeoutError and expose the applied timeout.
- - Add four regression tests.
Validation:
- Ruff passed.
- - Four focused pytest tests passed.